### PR TITLE
Fix face tracking data initialization

### DIFF
--- a/ViveStreamingEyes.cs
+++ b/ViveStreamingEyes.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Elements.Core;
 using FrooxEngine;
 using ViveStreamingFaceTrackingModule;
@@ -14,7 +14,7 @@ namespace ViveStreamingFaceTrackingForResonite
             public EyeData()
             {
                 data = new float[(int)FaceData.EyeDataIndex.MAX];
-                data.SetValue(float.NaN, 0);
+                Array.Fill(data, float.NaN);
             }
 
             public float this[FaceData.EyeDataIndex index] => data[(int)index];

--- a/ViveStreamingMouth.cs
+++ b/ViveStreamingMouth.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Elements.Core;
 using FrooxEngine;
 using ViveStreamingFaceTrackingModule;
@@ -14,7 +14,7 @@ namespace ViveStreamingFaceTrackingForResonite
             public MouthData()
             {
                 data = new float[(int)FaceData.LipDataIndex.Max];
-                data.SetValue(float.NaN, 0);
+                Array.Fill(data, float.NaN);
             }
 
             public readonly float this[FaceData.LipDataIndex index] => data[(int)index];


### PR DESCRIPTION
## Summary
- fill eye and mouth tracking arrays with `float.NaN` to avoid using default `0` values
- remove duplicate `using System;` directives caused by BOM

## Testing
- `git status --short`
