### PR TITLE
Fix mouth and eye data initialization

### DIFF
--- a/ViveStreamingEyes.cs
+++ b/ViveStreamingEyes.cs
@@ -14,7 +14,10 @@ namespace ViveStreamingFaceTrackingForResonite
             public EyeData()
             {
                 data = new float[(int)FaceData.EyeDataIndex.MAX];
-                Array.Fill(data, float.NaN);
+                for (var i = 0; i < data.Length; i++)
+                {
+                    data[i] = float.NaN;
+                }
             }
 
             public float this[FaceData.EyeDataIndex index] => data[(int)index];

--- a/ViveStreamingMouth.cs
+++ b/ViveStreamingMouth.cs
@@ -14,7 +14,10 @@ namespace ViveStreamingFaceTrackingForResonite
             public MouthData()
             {
                 data = new float[(int)FaceData.LipDataIndex.Max];
-                Array.Fill(data, float.NaN);
+                for (var i = 0; i < data.Length; i++)
+                {
+                    data[i] = float.NaN;
+                }
             }
 
             public readonly float this[FaceData.LipDataIndex index] => data[(int)index];


### PR DESCRIPTION
## Summary
- swap `Array.Fill` for loops in `MouthData` and `EyeData` constructors to assign `float.NaN`

## Testing
- `dotnet build --no-restore` *(fails: `dotnet` not found)*