### PR TITLE
Refactor active state handling in driver

### DIFF
--- a/ViveStreamingFaceTrackingDriver.cs
+++ b/ViveStreamingFaceTrackingDriver.cs
@@ -22,7 +22,7 @@ namespace ViveStreamingFaceTrackingForResonite
         private static string? lipData;
 
         private bool _tracking;
-        public bool active;
+        public bool IsActive { get; set; }
 
         public ViveStreamingFaceTrackingDriver()
         {
@@ -147,7 +147,7 @@ namespace ViveStreamingFaceTrackingForResonite
                 _tracking = false;
             }
 
-            if (connected && !_tracking && active)
+            if (connected && !_tracking && IsActive)
             {
                 if (!VS_PC_SDK.VS_StartFaceTracking())
                 {
@@ -157,7 +157,7 @@ namespace ViveStreamingFaceTrackingForResonite
                 _tracking = true;
             }
 
-            if (connected && _tracking && !active)
+            if (connected && _tracking && !IsActive)
             {
                 if (!VS_PC_SDK.VS_StopFaceTracking())
                 {
@@ -178,7 +178,7 @@ namespace ViveStreamingFaceTrackingForResonite
 
         public void Dispose()
         {
-            active = false;
+            IsActive = false;
 
             var result = VS_PC_SDK.VS_Release();
             if (result != 0)

--- a/ViveStreamingFaceTrackingMod.cs
+++ b/ViveStreamingFaceTrackingMod.cs
@@ -54,11 +54,11 @@ namespace ViveStreamingFaceTrackingForResonite
         {
             config = modInstance?.GetConfiguration();
 
-            driver.active = config?.GetValue(enabledkey) ?? true;
+            driver.IsActive = config?.GetValue(enabledkey) ?? true;
 
             enabledkey.OnChanged += (_) =>
             {
-                driver.active = config?.GetValue(enabledkey) ?? true;
+                driver.IsActive = config?.GetValue(enabledkey) ?? true;
             };
         }
 


### PR DESCRIPTION
## Summary
- replace `active` bool field with `IsActive` auto property in `ViveStreamingFaceTrackingDriver`
- update references in `ViveStreamingFaceTrackingMod`

## Testing
- `dotnet build ViveStreamingFaceTrackingForResonite.csproj -c Release` *(fails: unable to restore packages)*