### PR TITLE
Fix release note typo

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -18,6 +18,6 @@ changelog:
     - title: 💄 UI Styles
       labels:
       - style
-    - title: Othre Changes
+    - title: Other Changes
       labels:
       - "*"


### PR DESCRIPTION
## Summary
- correct typo `Othre Changes` to `Other Changes` in `.github/release.yml`

## Testing
- `dotnet build ViveStreamingFaceTrackingForResonite.sln -c Release` *(fails: Unable to load service index)*